### PR TITLE
Support ignoring incoming resources

### DIFF
--- a/fn_test.go
+++ b/fn_test.go
@@ -33,6 +33,43 @@ func TestRunFunction(t *testing.T) {
 		args   args
 		want   want
 	}{
+		"IgnoredResource": {
+			reason: "We should return early if the incoming resource should be ignored.",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Context: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"ops.upbound.io/ignored-resource": structpb.NewBoolValue(true),
+					}},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Context: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"ops.upbound.io/ignored-resource": structpb.NewBoolValue(true),
+					}},
+					Meta: &fnv1.ResponseMeta{
+						Ttl: &durationpb.Duration{
+							Seconds: 60,
+						},
+					},
+					Conditions: []*fnv1.Condition{
+						{
+							Type:   "FunctionSuccess",
+							Status: fnv1.Status_STATUS_CONDITION_TRUE,
+							Reason: "Success",
+							Target: fnv1.Target_TARGET_COMPOSITE_AND_CLAIM.Enum(),
+						},
+					},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_NORMAL,
+							Message:  "received an ignored resource, skipping",
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+				},
+			},
+		},
 		"ResponseIsReturned": {
 			reason: "The Function should return a fatal result if credential cannot be found.",
 			args: args{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This should be merged after #15 .

This changeset adds support for ignoring resources and simply returning early. This is helpful in operation workflows when noise is injected into the pipeline. Some examples:
* If using a `WatchOperation` and setting a watch on Events.
* If using a `WatchOperation` and setting a watch on all pods.
* etc

In these cases, without a preceding function identifying that the resource is unimportant and then communicating that later functions in the pipeline should be skipping/ignored, we could end up erroneously calling claude frequently.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
